### PR TITLE
add Swagger documentation for creating a new order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Order Service
+
+## 🚀 Overview
+
+The **Order Service** is a RESTful API that facilitates the management of orders within an e-commerce or business platform. It enables users to create and manage orders, including linking them to payment types and products.
+
+This service is built using **Spring Boot**, **Spring Data JPA**, and **Feign Clients** to integrate with other services (like payment types and product services) for a fully functional order management system.
+
+## 🌟 Key Features
+
+- **RESTful API**: Provides endpoints for order creation and retrieval.
+- **Feign Integration**: Uses Feign clients to call external services for product and payment type information.
+- **Order Management**: Handles order details such as order number, status, client ID, total amount, and related products.
+
+## 🔑 API Endpoints
+
+### 1. **POST** `/api/orders`
+Creates a new order.
+
+**Request Body**:
+- `orderNumber`: The order number (generated automatically).
+- `orderDate`: The date and time of the order.
+- `totalAmount`: The total amount of the order.
+- `status`: The status of the order (e.g., "pending", "completed").
+- `clientId`: The ID of the client making the order.
+- `paymentTypeId`: The ID of the payment method used.
+- `items`: A list of order items, each containing the product ID, quantity, and price.
+
+**Response**:
+- Returns the created `Order` object.
+
+## 🔧 Technologies Used
+
+- **Spring Boot**: Framework for building the application.
+- **JPA** (Java Persistence API): Handles database interaction for orders and order items.
+- **Feign Clients**: Used for calling external services (product and payment type services).
+- **H2 Database** (or other relational DB): Stores order and order item data.
+- **Java**: The programming language used to develop the service.
+
+## 💡 Use Case
+
+This service is ideal for systems that need to manage orders in a flexible way. It integrates seamlessly with other services (such as product and payment services) to provide a robust order management system for e-commerce platforms, POS systems, or any service that handles customer orders.

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.0.2</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/mipagina/order_service/controller/OrderController.java
+++ b/src/main/java/com/mipagina/order_service/controller/OrderController.java
@@ -2,6 +2,10 @@ package com.mipagina.order_service.controller;
 
 import com.mipagina.order_service.model.Order;
 import com.mipagina.order_service.service.IOrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,9 +21,15 @@ public class OrderController {
     @Autowired
     private IOrderService orderService;
 
-
+    @Operation(summary = "Create a new order", description = "Creates a new order in the system based on the provided order details.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Order created successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid input provided")
+    })
     @PostMapping
-    public ResponseEntity<Order> createOrder(@RequestBody Order order) {
+    public ResponseEntity<Order> createOrder(
+            @Parameter(description = "Order object that contains the details of the new order", required = true)
+            @RequestBody Order order) {
         return new ResponseEntity<>(orderService.createOrder(order), HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/mipagina/order_service/model/Order.java
+++ b/src/main/java/com/mipagina/order_service/model/Order.java
@@ -1,6 +1,7 @@
 package com.mipagina.order_service.model;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,15 +11,28 @@ import java.util.List;
 public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "Unique identifier of the order", example = "1")
     private Long id;
+
+    @Schema(description = "Unique order number", example = "ORD123456", required = true)
     private String orderNumber;
+
+    @Schema(description = "Date and time when the order was placed", example = "2025-02-05T15:30:00", required = true)
     private LocalDateTime orderDate;
+
+    @Schema(description = "Total amount for the order", example = "250.75", required = true)
     private Double totalAmount;
+
+    @Schema(description = "Status of the order", example = "Pending", required = true)
     private String status;
+
+    @Schema(description = "Unique identifier of the client placing the order", example = "101", required = true)
     private Long clientId;
+
+    @Schema(description = "Unique identifier for the payment type used", example = "1", required = true)
     private Long paymentTypeId;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "order")
+@OneToMany(cascade = CascadeType.ALL, mappedBy = "order")
     @JsonManagedReference
     private List<OrderItem> items;
 

--- a/src/main/java/com/mipagina/order_service/model/OrderItem.java
+++ b/src/main/java/com/mipagina/order_service/model/OrderItem.java
@@ -1,6 +1,7 @@
 package com.mipagina.order_service.model;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 
 @Entity
@@ -8,13 +9,23 @@ import jakarta.persistence.*;
 public class OrderItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "Unique identifier of the order item", example = "1")
     private Long id;
+
+    @Schema(description = "Unique identifier for the product in the order", example = "2001", required = true)
     private Long productId;
+
+    @Schema(description = "Quantity of the product ordered", example = "2", required = true)
     private Integer quantity;
+
+    @Schema(description = "Unit price of the product", example = "100.25", required = true)
     private Double unitPrice;
+
+    @Schema(description = "Subtotal for the order item (quantity * unit price)", example = "200.50", required = true)
     private Double subtotal;
 
-    @ManyToOne
+
+@ManyToOne
     @JoinColumn(name = "order_id")
     @JsonBackReference
     private Order order;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,5 +5,5 @@ eureka.client.service-url.defaultZone=http://localhost:8761/eureka
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://localhost:3306/restaurant_orders?serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=admin
+spring.datasource.password=12345
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
This update enhances the API documentation by adding Swagger annotations to both the models and the controller for the order creation functionality. The changes improve clarity and provide detailed information about the OrderController and its createOrder endpoint, making it easier for developers to understand the API structure and how to interact with it.

Reviewer: @JuanGuevara90







